### PR TITLE
fix brownfield detection for empty repos

### DIFF
--- a/commands/gsd/new-project.md
+++ b/commands/gsd/new-project.md
@@ -59,7 +59,7 @@ This is the most leveraged moment in any project. Deep questioning here means be
 
 3. **Detect existing code (brownfield detection):**
    ```bash
-   CODE_FILES=$(find . \( -path './.git' -o -path './deps' \) -prune -o -type f \( -name "*.py" -o -name "*.go" -o -name "*.rs" -o -name "*.swift" -o -name "*.java" -o -name "*.js" -o -name "*.jsx" -o -name "*.ts" -o -name "*.tsx" \) -print 2>/dev/null | head -20)
+   CODE_FILES=$(find . \( -path './.git' -o -path './deps' \) -prune -o -type f \( -name "*.py" -o -name "*.go" -o -name "*.rs" -o -name "*.swift" -o -name "*.java" -o -name "*.js" -o -name "*.jsx" -o -name "*.ts" -o -name "*.tsx" \) -print 2>/dev/null | awk 'NR <= 20 { print }')
    if [ -f project.manifest ] || [ -f requirements.txt ] || [ -f pyproject.toml ] || [ -f Cargo.toml ] || [ -f go.mod ] || [ -f package.json ] || [ -f Package.swift ]; then
        HAS_PACKAGE="yes"
    else

--- a/scripts/smoke/bootstrap-contract.sh
+++ b/scripts/smoke/bootstrap-contract.sh
@@ -31,6 +31,7 @@ run_project_bash() {
 [ "$#" -eq 1 ] || usage
 
 require_cmd bash
+require_cmd awk
 require_cmd find
 require_cmd git
 require_cmd grep
@@ -59,6 +60,18 @@ temp_home="$(resolve_path "$temp_home")"
 project_dir="$(resolve_path "$project_dir")"
 project_name="$(basename "$project_dir")"
 gsd_dir="$project_dir/.gsd"
+brownfield_code_files_logic="CODE_FILES=\$(find . \\( -path './.git' -o -path './deps' \\) -prune -o -type f \\( -name \"*.py\" -o -name \"*.go\" -o -name \"*.rs\" -o -name \"*.swift\" -o -name \"*.java\" -o -name \"*.js\" -o -name \"*.jsx\" -o -name \"*.ts\" -o -name \"*.tsx\" \\) -print 2>/dev/null | awk 'NR <= 20 { print }')"
+brownfield_has_package_condition='[ -f project.manifest ] || [ -f requirements.txt ] || [ -f pyproject.toml ] || [ -f Cargo.toml ] || [ -f go.mod ] || [ -f package.json ] || [ -f Package.swift ]'
+brownfield_has_package_logic="if $brownfield_has_package_condition; then
+  HAS_PACKAGE=\"yes\"
+else
+  HAS_PACKAGE=\"\"
+fi"
+brownfield_has_codebase_map_logic='if [ -d .planning/codebase ]; then
+  HAS_CODEBASE_MAP="yes"
+else
+  HAS_CODEBASE_MAP=""
+fi'
 
 run_in_project "$GSD_BIN" --version >/dev/null
 run_in_project "$GSD_BIN" install --platform=both --local >/dev/null
@@ -104,8 +117,8 @@ assert_not_contains "$claude_prompt_content" "@~/.gsd/"
 assert_contains "$codex_prompt_content" "@.gsd/references/questioning.md"
 assert_contains "$codex_prompt_content" ".planning/PROJECT.md"
 assert_not_contains "$codex_prompt_content" "@~/.gsd/"
-assert_contains "$claude_prompt_content" 'CODE_FILES=$(find . \( -path '\''./.git'\'' -o -path '\''./deps'\'' \) -prune -o -type f \( -name "*.py" -o -name "*.go" -o -name "*.rs" -o -name "*.swift" -o -name "*.java" -o -name "*.js" -o -name "*.jsx" -o -name "*.ts" -o -name "*.tsx" \) -print 2>/dev/null | head -20)'
-assert_contains "$claude_prompt_content" 'if [ -f project.manifest ] || [ -f requirements.txt ] || [ -f pyproject.toml ] || [ -f Cargo.toml ] || [ -f go.mod ] || [ -f package.json ] || [ -f Package.swift ]; then'
+assert_contains "$claude_prompt_content" "$brownfield_code_files_logic"
+assert_contains "$claude_prompt_content" "if $brownfield_has_package_condition; then"
 assert_contains "$claude_prompt_content" 'HAS_PACKAGE="yes"'
 assert_contains "$claude_prompt_content" 'if [ -d .planning/codebase ]; then'
 assert_contains "$claude_prompt_content" 'HAS_CODEBASE_MAP="yes"'
@@ -152,29 +165,17 @@ fi')"
 assert_contains "$git_output" "Initialized new git repo"
 assert_dir "$project_dir/.git"
 
-brownfield_output="$(run_project_bash 'CODE_FILES=$(find . \( -path '\''./.git'\'' -o -path '\''./deps'\'' \) -prune -o -type f \( -name "*.py" -o -name "*.go" -o -name "*.rs" -o -name "*.swift" -o -name "*.java" -o -name "*.js" -o -name "*.jsx" -o -name "*.ts" -o -name "*.tsx" \) -print 2>/dev/null | head -20)
-if [ -f project.manifest ] || [ -f requirements.txt ] || [ -f pyproject.toml ] || [ -f Cargo.toml ] || [ -f go.mod ] || [ -f package.json ] || [ -f Package.swift ]; then
-  HAS_PACKAGE="yes"
-else
-  HAS_PACKAGE=""
-fi
-if [ -d .planning/codebase ]; then
-  HAS_CODEBASE_MAP="yes"
-else
-  HAS_CODEBASE_MAP=""
-fi
-printf "CODE_FILES=%s\nHAS_PACKAGE=%s\nHAS_CODEBASE_MAP=%s\n" "$CODE_FILES" "$HAS_PACKAGE" "$HAS_CODEBASE_MAP"')"
+brownfield_output="$(run_project_bash "${brownfield_code_files_logic}
+${brownfield_has_package_logic}
+${brownfield_has_codebase_map_logic}
+printf \"CODE_FILES=%s\nHAS_PACKAGE=%s\nHAS_CODEBASE_MAP=%s\n\" \"\$CODE_FILES\" \"\$HAS_PACKAGE\" \"\$HAS_CODEBASE_MAP\"")"
 printf '%s\n' "$brownfield_output" | grep -Fx 'CODE_FILES=' >/dev/null || fail "expected no brownfield code files"
 printf '%s\n' "$brownfield_output" | grep -Fx 'HAS_PACKAGE=' >/dev/null || fail "expected no package manifest"
 printf '%s\n' "$brownfield_output" | grep -Fx 'HAS_CODEBASE_MAP=' >/dev/null || fail "expected no codebase map"
 
 touch "$project_dir/requirements.txt"
-package_detection_output="$(run_project_bash 'if [ -f project.manifest ] || [ -f requirements.txt ] || [ -f pyproject.toml ] || [ -f Cargo.toml ] || [ -f go.mod ] || [ -f package.json ] || [ -f Package.swift ]; then
-  HAS_PACKAGE="yes"
-else
-  HAS_PACKAGE=""
-fi
-printf "HAS_PACKAGE=%s\n" "$HAS_PACKAGE"')"
+package_detection_output="$(run_project_bash "${brownfield_has_package_logic}
+printf \"HAS_PACKAGE=%s\n\" \"\$HAS_PACKAGE\"")"
 printf '%s\n' "$package_detection_output" | grep -Fx 'HAS_PACKAGE=yes' >/dev/null || fail "expected manifest detection to recognize requirements.txt"
 rm "$project_dir/requirements.txt"
 
@@ -184,13 +185,9 @@ cat > "$project_dir/package.json" <<'EOF_PACKAGE'
 }
 EOF_PACKAGE
 touch "$project_dir/app.ts"
-js_brownfield_output="$(run_project_bash 'CODE_FILES=$(find . \( -path '\''./.git'\'' -o -path '\''./deps'\'' \) -prune -o -type f \( -name "*.py" -o -name "*.go" -o -name "*.rs" -o -name "*.swift" -o -name "*.java" -o -name "*.js" -o -name "*.jsx" -o -name "*.ts" -o -name "*.tsx" \) -print 2>/dev/null | head -20)
-if [ -f project.manifest ] || [ -f requirements.txt ] || [ -f pyproject.toml ] || [ -f Cargo.toml ] || [ -f go.mod ] || [ -f package.json ] || [ -f Package.swift ]; then
-  HAS_PACKAGE="yes"
-else
-  HAS_PACKAGE=""
-fi
-printf "CODE_FILES=%s\nHAS_PACKAGE=%s\n" "$CODE_FILES" "$HAS_PACKAGE"')"
+js_brownfield_output="$(run_project_bash "${brownfield_code_files_logic}
+${brownfield_has_package_logic}
+printf \"CODE_FILES=%s\nHAS_PACKAGE=%s\n\" \"\$CODE_FILES\" \"\$HAS_PACKAGE\"")"
 printf '%s\n' "$js_brownfield_output" | grep -Fx 'CODE_FILES=./app.ts' >/dev/null || fail "expected TypeScript brownfield detection"
 printf '%s\n' "$js_brownfield_output" | grep -Fx 'HAS_PACKAGE=yes' >/dev/null || fail "expected package.json brownfield detection"
 rm "$project_dir/package.json" "$project_dir/app.ts"


### PR DESCRIPTION
## Summary
- make the new-project brownfield detector safe under strict shell semantics on empty repos
- detect common JS/TS brownfield projects via source extensions and package.json/pyproject.toml
- tighten the bootstrap smoke to run the prompt logic under bash -euo pipefail and cover the JS/TS case

## Validation
- cd installer && nimble verify -y
- ./scripts/smoke/live-new-project.sh installer/gsd